### PR TITLE
Remove unsafe tags from Writer trait

### DIFF
--- a/benches/avp_impl/decode.rs
+++ b/benches/avp_impl/decode.rs
@@ -16,7 +16,7 @@ fn make_test(size: usize, rng: &mut impl Rng) -> Vec<u8> {
 
     for _ in 0..size {
         let index = rng.gen_range(0..corpus.len());
-        unsafe { corpus[index].write(&mut writer) };
+        corpus[index].write(&mut writer);
     }
 
     writer.data

--- a/benches/avp_impl/encode.rs
+++ b/benches/avp_impl/encode.rs
@@ -31,7 +31,7 @@ pub(crate) fn avp_encode(c: &mut Criterion) {
 
         let mut tmp_writer = VecWriter::new();
         for avp in test_case.iter() {
-            unsafe { avp.write(&mut tmp_writer) };
+            avp.write(&mut tmp_writer);
         }
         group.throughput(Throughput::Bytes(tmp_writer.data.len() as u64));
 
@@ -42,7 +42,7 @@ pub(crate) fn avp_encode(c: &mut Criterion) {
                 b.iter(|| {
                     let mut writer = VecWriter::new();
                     for avp in data.iter() {
-                        unsafe { avp.write(&mut writer) };
+                        avp.write(&mut writer);
                     }
                     writer.data;
                 });

--- a/src/common/vec_writer.rs
+++ b/src/common/vec_writer.rs
@@ -27,39 +27,42 @@ impl Writer for VecWriter {
     }
 
     #[inline]
-    unsafe fn write_bytes_unchecked(&mut self, bytes: &[u8]) {
+    fn write_bytes(&mut self, bytes: &[u8]) {
         self.data.extend_from_slice(bytes);
     }
 
     #[inline]
-    unsafe fn write_bytes_unchecked_at(&mut self, bytes: &[u8], offset: usize) {
+    fn write_bytes_at(&mut self, bytes: &[u8], offset: usize) {
         assert!(offset + bytes.len() <= self.data.len());
-        std::ptr::copy_nonoverlapping(
-            bytes.as_ptr(),
-            self.data[offset..].as_mut_ptr(),
-            bytes.len(),
-        );
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                self.data[offset..].as_mut_ptr(),
+                bytes.len(),
+            );
+        }
     }
 
     #[inline]
-    unsafe fn write_u8_unchecked(&mut self, value: u8) {
+    fn write_u8(&mut self, value: u8) {
         self.data.push(value);
     }
 
     #[inline]
-    unsafe fn write_u16_be_unchecked(&mut self, value: u16) {
+    fn write_u16_be(&mut self, value: u16) {
         let bytes = value.to_be_bytes();
         self.data.extend_from_slice(&bytes);
     }
 
     #[inline]
-    unsafe fn write_u32_be_unchecked(&mut self, value: u32) {
+    fn write_u32_be(&mut self, value: u32) {
         let bytes = value.to_be_bytes();
         self.data.extend_from_slice(&bytes);
     }
 
     #[inline]
-    unsafe fn write_u64_be_unchecked(&mut self, value: u64) {
+    fn write_u64_be(&mut self, value: u64) {
         let bytes = value.to_be_bytes();
         self.data.extend_from_slice(&bytes);
     }

--- a/src/common/vec_writer/tests.rs
+++ b/src/common/vec_writer/tests.rs
@@ -11,7 +11,7 @@ fn write_bytes_len() {
 
     let mut w = VecWriter::new();
 
-    unsafe { w.write_bytes_unchecked(&input) };
+    w.write_bytes(&input);
     assert_eq!(w.len(), input.len());
 }
 
@@ -19,16 +19,16 @@ fn write_bytes_len() {
 fn write_integers_len() {
     let mut w = VecWriter::new();
 
-    unsafe { w.write_u8_unchecked(0x00) };
+    w.write_u8(0x00);
     assert_eq!(w.len(), 1);
 
-    unsafe { w.write_u16_be_unchecked(0x0102) };
+    w.write_u16_be(0x0102);
     assert_eq!(w.len(), 3);
 
-    unsafe { w.write_u32_be_unchecked(0x03040506) };
+    w.write_u32_be(0x03040506);
     assert_eq!(w.len(), 7);
 
-    unsafe { w.write_u64_be_unchecked(0x0708090a0b0c0d0e) };
+    w.write_u64_be(0x0708090a0b0c0d0e);
     assert_eq!(w.len(), 15);
 }
 
@@ -43,7 +43,7 @@ fn write_bytes() {
 
     let mut w = VecWriter::new();
 
-    unsafe { w.write_bytes_unchecked(&input) };
+    w.write_bytes(&input);
     assert_eq!(w.data, input);
 }
 
@@ -51,12 +51,10 @@ fn write_bytes() {
 fn write_integers() {
     let mut w = VecWriter::new();
 
-    unsafe {
-        w.write_u8_unchecked(0x00);
-        w.write_u16_be_unchecked(0x0102);
-        w.write_u32_be_unchecked(0x03040506);
-        w.write_u64_be_unchecked(0x0708090a0b0c0d0e);
-    }
+    w.write_u8(0x00);
+    w.write_u16_be(0x0102);
+    w.write_u32_be(0x03040506);
+    w.write_u64_be(0x0708090a0b0c0d0e);
 
     assert_eq!(
         w.data,

--- a/src/common/writer.rs
+++ b/src/common/writer.rs
@@ -11,37 +11,25 @@ pub trait Writer {
 
     /// # Summary
     /// Write byte slice.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_bytes_unchecked(&mut self, bytes: &[u8]);
+    fn write_bytes(&mut self, bytes: &[u8]);
 
     /// # Summary
     /// Write a byte slice at a given offset.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_bytes_unchecked_at(&mut self, bytes: &[u8], offset: usize);
+    fn write_bytes_at(&mut self, bytes: &[u8], offset: usize);
 
     /// # Summary
     /// Write a single u8.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_u8_unchecked(&mut self, value: u8);
+    fn write_u8(&mut self, value: u8);
 
     /// # Summary
     /// Write a native u16 as big endian data.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_u16_be_unchecked(&mut self, value: u16);
+    fn write_u16_be(&mut self, value: u16);
 
     /// # Summary
     /// Write a native u32 as big endian data.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_u32_be_unchecked(&mut self, value: u32);
+    fn write_u32_be(&mut self, value: u32);
 
     /// # Summary
     /// Write a native u64 as big endian data.
-    /// # Safety
-    /// This function is marked as unsafe because it offers no error handling mechanism.
-    unsafe fn write_u64_be_unchecked(&mut self, value: u64);
+    fn write_u64_be(&mut self, value: u64);
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -107,11 +107,8 @@ where
 
     /// # Summary
     /// Write a `Message` using a mutable `Writer`.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because the `Writer` trait offers no error handling mechanism.
     #[inline]
-    pub unsafe fn write(&self, writer: &mut impl Writer) {
+    pub fn write(&self, writer: &mut impl Writer) {
         match self {
             Message::Control(control) => control.write(Self::PROTOCOL_VERSION, writer),
             Message::Data(data) => data.write(Self::PROTOCOL_VERSION, writer),

--- a/src/message/avp/tests/write_read.rs
+++ b/src/message/avp/tests/write_read.rs
@@ -9,7 +9,7 @@ macro_rules! io_tests {
             // Serialize input
             let input = $input;
             let mut w = VecWriter::new();
-            unsafe { $input.write(&mut w) };
+            $input.write(&mut w);
 
             // Deserialize to output
             let mut r = SliceReader::from(&w.data);
@@ -96,7 +96,7 @@ fn hidden() {
         .clone()
         .hide(&secret, &rv, &length_padding, &alignment_padding);
     let mut w = VecWriter::new();
-    unsafe { hidden.write(&mut w) };
+    hidden.write(&mut w);
 
     println!("{:?}", w.data);
 

--- a/src/message/avp/types/assigned_session_id.rs
+++ b/src/message/avp/types/assigned_session_id.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for AssignedSessionId {
 
 impl WritableAVP for AssignedSessionId {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.value);
     }
 }

--- a/src/message/avp/types/assigned_tunnel_id.rs
+++ b/src/message/avp/types/assigned_tunnel_id.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for AssignedTunnelId {
 
 impl WritableAVP for AssignedTunnelId {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.value);
     }
 }

--- a/src/message/avp/types/bearer_capabilities.rs
+++ b/src/message/avp/types/bearer_capabilities.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for BearerCapabilities {
 
 impl WritableAVP for BearerCapabilities {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.data);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.data);
     }
 }

--- a/src/message/avp/types/bearer_type.rs
+++ b/src/message/avp/types/bearer_type.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for BearerType {
 
 impl WritableAVP for BearerType {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.data);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.data);
     }
 }

--- a/src/message/avp/types/call_errors.rs
+++ b/src/message/avp/types/call_errors.rs
@@ -51,17 +51,17 @@ impl QueryableAVP for CallErrors {
 
 impl WritableAVP for CallErrors {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
 
         // Reserved
-        writer.write_bytes_unchecked(&[0x00, 0x00]);
+        writer.write_bytes(&[0x00, 0x00]);
 
-        writer.write_u32_be_unchecked(self.crc_errors);
-        writer.write_u32_be_unchecked(self.framing_errors);
-        writer.write_u32_be_unchecked(self.hardware_overruns);
-        writer.write_u32_be_unchecked(self.buffer_overruns);
-        writer.write_u32_be_unchecked(self.timeout_errors);
-        writer.write_u32_be_unchecked(self.alignment_errors);
+        writer.write_u32_be(self.crc_errors);
+        writer.write_u32_be(self.framing_errors);
+        writer.write_u32_be(self.hardware_overruns);
+        writer.write_u32_be(self.buffer_overruns);
+        writer.write_u32_be(self.timeout_errors);
+        writer.write_u32_be(self.alignment_errors);
     }
 }

--- a/src/message/avp/types/call_serial_number.rs
+++ b/src/message/avp/types/call_serial_number.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for CallSerialNumber {
 
 impl WritableAVP for CallSerialNumber {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.value);
     }
 }

--- a/src/message/avp/types/called_number.rs
+++ b/src/message/avp/types/called_number.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for CalledNumber {
 
 impl WritableAVP for CalledNumber {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(self.value.as_bytes());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(self.value.as_bytes());
     }
 }

--- a/src/message/avp/types/calling_number.rs
+++ b/src/message/avp/types/calling_number.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for CallingNumber {
 
 impl WritableAVP for CallingNumber {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(self.value.as_bytes());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(self.value.as_bytes());
     }
 }

--- a/src/message/avp/types/challenge.rs
+++ b/src/message/avp/types/challenge.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for Challenge {
 
 impl WritableAVP for Challenge {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/challenge_response.rs
+++ b/src/message/avp/types/challenge_response.rs
@@ -20,7 +20,11 @@ impl ChallengeResponse {
         }
 
         Ok(Self {
-            value: unsafe { reader.bytes(16)?.borrow().try_into().unwrap_unchecked() },
+            value: reader
+                .bytes(16)?
+                .borrow()
+                .try_into()
+                .map_err(|_| "Insufficient data")?,
         })
     }
 }
@@ -46,8 +50,8 @@ impl QueryableAVP for ChallengeResponse {
 
 impl WritableAVP for ChallengeResponse {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/firmware_revision.rs
+++ b/src/message/avp/types/firmware_revision.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for FirmwareRevision {
 
 impl WritableAVP for FirmwareRevision {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.value);
     }
 }

--- a/src/message/avp/types/framing_capabilities.rs
+++ b/src/message/avp/types/framing_capabilities.rs
@@ -49,8 +49,8 @@ impl QueryableAVP for FramingCapabilities {
 
 impl WritableAVP for FramingCapabilities {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.data);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.data);
     }
 }

--- a/src/message/avp/types/framing_type.rs
+++ b/src/message/avp/types/framing_type.rs
@@ -47,8 +47,8 @@ impl QueryableAVP for FramingType {
 
 impl WritableAVP for FramingType {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.data);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.data);
     }
 }

--- a/src/message/avp/types/hidden.rs
+++ b/src/message/avp/types/hidden.rs
@@ -16,8 +16,8 @@ impl QueryableAVP for Hidden {
 
 impl WritableAVP for Hidden {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(self.attribute_type);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(self.attribute_type);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/host_name.rs
+++ b/src/message/avp/types/host_name.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for HostName {
 
 impl WritableAVP for HostName {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/initial_received_lcp_conf_req.rs
+++ b/src/message/avp/types/initial_received_lcp_conf_req.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for InitialReceivedLcpConfReq {
 
 impl WritableAVP for InitialReceivedLcpConfReq {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/last_received_lcp_conf_req.rs
+++ b/src/message/avp/types/last_received_lcp_conf_req.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for LastReceivedLcpConfReq {
 
 impl WritableAVP for LastReceivedLcpConfReq {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/last_sent_lcp_conf_req.rs
+++ b/src/message/avp/types/last_sent_lcp_conf_req.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for LastSentLcpConfReq {
 
 impl WritableAVP for LastSentLcpConfReq {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/maximum_bps.rs
+++ b/src/message/avp/types/maximum_bps.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for MaximumBps {
 
 impl WritableAVP for MaximumBps {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.value);
     }
 }

--- a/src/message/avp/types/message_type.rs
+++ b/src/message/avp/types/message_type.rs
@@ -87,8 +87,8 @@ impl QueryableAVP for MessageType {
 
 impl WritableAVP for MessageType {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.get_code())
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.get_code())
     }
 }

--- a/src/message/avp/types/minimum_bps.rs
+++ b/src/message/avp/types/minimum_bps.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for MinimumBps {
 
 impl WritableAVP for MinimumBps {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.value);
     }
 }

--- a/src/message/avp/types/physical_channel_id.rs
+++ b/src/message/avp/types/physical_channel_id.rs
@@ -52,8 +52,8 @@ impl QueryableAVP for PhysicalChannelId {
 
 impl WritableAVP for PhysicalChannelId {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/private_group_id.rs
+++ b/src/message/avp/types/private_group_id.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for PrivateGroupId {
 
 impl WritableAVP for PrivateGroupId {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/protocol_version.rs
+++ b/src/message/avp/types/protocol_version.rs
@@ -32,8 +32,8 @@ impl QueryableAVP for ProtocolVersion {
 
 impl WritableAVP for ProtocolVersion {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&[self.version, self.revision]);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&[self.version, self.revision]);
     }
 }

--- a/src/message/avp/types/proxy_authen_challenge.rs
+++ b/src/message/avp/types/proxy_authen_challenge.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for ProxyAuthenChallenge {
 
 impl WritableAVP for ProxyAuthenChallenge {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/proxy_authen_id.rs
+++ b/src/message/avp/types/proxy_authen_id.rs
@@ -47,8 +47,8 @@ impl From<ProxyAuthenId> for u8 {
 
 impl WritableAVP for ProxyAuthenId {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&[0x00, self.value]);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&[0x00, self.value]);
     }
 }

--- a/src/message/avp/types/proxy_authen_name.rs
+++ b/src/message/avp/types/proxy_authen_name.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for ProxyAuthenName {
 
 impl WritableAVP for ProxyAuthenName {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/proxy_authen_response.rs
+++ b/src/message/avp/types/proxy_authen_response.rs
@@ -43,8 +43,8 @@ impl QueryableAVP for ProxyAuthenResponse {
 
 impl WritableAVP for ProxyAuthenResponse {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/proxy_authen_type.rs
+++ b/src/message/avp/types/proxy_authen_type.rs
@@ -42,8 +42,8 @@ impl QueryableAVP for ProxyAuthenType {
 
 impl WritableAVP for ProxyAuthenType {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked((*self).into());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be((*self).into());
     }
 }

--- a/src/message/avp/types/q931_cause_code.rs
+++ b/src/message/avp/types/q931_cause_code.rs
@@ -54,12 +54,12 @@ impl QueryableAVP for Q931CauseCode {
 
 impl WritableAVP for Q931CauseCode {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.cause_code);
-        writer.write_u8_unchecked(self.cause_msg);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.cause_code);
+        writer.write_u8(self.cause_msg);
         if let Some(value) = &self.advisory {
-            writer.write_bytes_unchecked(value.as_bytes());
+            writer.write_bytes(value.as_bytes());
         }
     }
 }

--- a/src/message/avp/types/random_vector.rs
+++ b/src/message/avp/types/random_vector.rs
@@ -20,7 +20,11 @@ impl RandomVector {
         }
 
         Ok(Self {
-            value: unsafe { reader.bytes(4)?.borrow().try_into().unwrap_unchecked() },
+            value: reader
+                .bytes(4)?
+                .borrow()
+                .try_into()
+                .map_err(|_| "Insufficient data")?,
         })
     }
 }
@@ -46,8 +50,8 @@ impl QueryableAVP for RandomVector {
 
 impl WritableAVP for RandomVector {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(&self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(&self.value);
     }
 }

--- a/src/message/avp/types/receive_window_size.rs
+++ b/src/message/avp/types/receive_window_size.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for ReceiveWindowSize {
 
 impl WritableAVP for ReceiveWindowSize {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.value);
     }
 }

--- a/src/message/avp/types/result_code.rs
+++ b/src/message/avp/types/result_code.rs
@@ -57,14 +57,14 @@ impl QueryableAVP for ResultCode {
 
 impl WritableAVP for ResultCode {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u16_be_unchecked(self.code.into());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u16_be(self.code.into());
         if let Some(error) = &self.error {
-            writer.write_u16_be_unchecked(error.error_type.into());
+            writer.write_u16_be(error.error_type.into());
 
             if let Some(message) = &error.error_message {
-                writer.write_bytes_unchecked(message.as_bytes());
+                writer.write_bytes(message.as_bytes());
             }
         }
     }

--- a/src/message/avp/types/rx_connect_speed.rs
+++ b/src/message/avp/types/rx_connect_speed.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for RxConnectSpeed {
 
 impl WritableAVP for RxConnectSpeed {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.value);
     }
 }

--- a/src/message/avp/types/sequencing_required.rs
+++ b/src/message/avp/types/sequencing_required.rs
@@ -17,7 +17,7 @@ impl QueryableAVP for SequencingRequired {
 
 impl WritableAVP for SequencingRequired {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
     }
 }

--- a/src/message/avp/types/sub_address.rs
+++ b/src/message/avp/types/sub_address.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for SubAddress {
 
 impl WritableAVP for SubAddress {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(self.value.as_bytes());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(self.value.as_bytes());
     }
 }

--- a/src/message/avp/types/tie_breaker.rs
+++ b/src/message/avp/types/tie_breaker.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for TieBreaker {
 
 impl WritableAVP for TieBreaker {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u64_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u64_be(self.value);
     }
 }

--- a/src/message/avp/types/tx_connect_speed.rs
+++ b/src/message/avp/types/tx_connect_speed.rs
@@ -44,8 +44,8 @@ impl QueryableAVP for TxConnectSpeed {
 
 impl WritableAVP for TxConnectSpeed {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_u32_be_unchecked(self.value);
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_u32_be(self.value);
     }
 }

--- a/src/message/avp/types/vendor_name.rs
+++ b/src/message/avp/types/vendor_name.rs
@@ -46,8 +46,8 @@ impl QueryableAVP for VendorName {
 
 impl WritableAVP for VendorName {
     #[inline]
-    unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(Self::ATTRIBUTE_TYPE);
-        writer.write_bytes_unchecked(self.value.as_bytes());
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(Self::ATTRIBUTE_TYPE);
+        writer.write_bytes(self.value.as_bytes());
     }
 }

--- a/src/message/control_message.rs
+++ b/src/message/control_message.rs
@@ -96,7 +96,7 @@ impl ControlMessage {
     }
 
     #[inline]
-    pub(crate) unsafe fn write(&self, protocol_version: u8, writer: &mut impl Writer) {
+    pub(crate) fn write(&self, protocol_version: u8, writer: &mut impl Writer) {
         let start_position = writer.len();
         let flags = Flags::new(
             MessageFlagType::Control,
@@ -112,13 +112,13 @@ impl ControlMessage {
         let length_position = writer.len();
 
         // Dummy octets to be overwritten
-        writer.write_bytes_unchecked(&[0, 0]);
+        writer.write_bytes(&[0, 0]);
 
         // Write rest of header
-        writer.write_u16_be_unchecked(self.tunnel_id);
-        writer.write_u16_be_unchecked(self.session_id);
-        writer.write_u16_be_unchecked(self.ns);
-        writer.write_u16_be_unchecked(self.nr);
+        writer.write_u16_be(self.tunnel_id);
+        writer.write_u16_be(self.session_id);
+        writer.write_u16_be(self.ns);
+        writer.write_u16_be(self.nr);
 
         // Write payload
         for avp in self.avps.iter() {
@@ -131,6 +131,6 @@ impl ControlMessage {
 
         // Overwrite dummy octets
         assert!(length <= u16::MAX as usize);
-        writer.write_bytes_unchecked_at(&(length as u16).to_be_bytes(), length_position);
+        writer.write_bytes_at(&(length as u16).to_be_bytes(), length_position);
     }
 }

--- a/src/message/data_message.rs
+++ b/src/message/data_message.rs
@@ -102,7 +102,7 @@ where
     }
 
     #[inline]
-    pub(crate) unsafe fn write(&self, protocol_version: u8, writer: &mut impl Writer) {
+    pub(crate) fn write(&self, protocol_version: u8, writer: &mut impl Writer) {
         let flags = Flags::new(
             MessageFlagType::Data,
             self.length.is_some(),
@@ -114,18 +114,18 @@ where
         flags.write(writer);
 
         if let Some(length) = self.length {
-            writer.write_u16_be_unchecked(length);
+            writer.write_u16_be(length);
         }
 
-        writer.write_u16_be_unchecked(self.tunnel_id);
-        writer.write_u16_be_unchecked(self.session_id);
+        writer.write_u16_be(self.tunnel_id);
+        writer.write_u16_be(self.session_id);
         if let Some((ns, nr)) = self.ns_nr {
-            writer.write_u16_be_unchecked(ns);
-            writer.write_u16_be_unchecked(nr);
+            writer.write_u16_be(ns);
+            writer.write_u16_be(nr);
         }
         if let Some(offset) = self.offset {
-            writer.write_u16_be_unchecked(offset);
+            writer.write_u16_be(offset);
         }
-        writer.write_bytes_unchecked(self.data.borrow());
+        writer.write_bytes(self.data.borrow());
     }
 }

--- a/src/message/flags.rs
+++ b/src/message/flags.rs
@@ -44,8 +44,8 @@ impl Flags {
     }
 
     #[inline]
-    pub unsafe fn write(&self, writer: &mut impl Writer) {
-        writer.write_u16_be_unchecked(self.data);
+    pub fn write(&self, writer: &mut impl Writer) {
+        writer.write_u16_be(self.data);
     }
 
     #[inline]

--- a/src/message/tests/write_read.rs
+++ b/src/message/tests/write_read.rs
@@ -15,7 +15,7 @@ fn empty_control() {
     });
 
     let mut w = VecWriter::new();
-    unsafe { in_msg.write(&mut w) };
+    in_msg.write(&mut w);
 
     assert_eq!(w.data.len(), TOTAL_LENGTH);
 


### PR DESCRIPTION
It is more reasonable if the trait impls do their best to be safe.