### PR TITLE
Fix new clippy lints

### DIFF
--- a/src/message/avp/header.rs
+++ b/src/message/avp/header.rs
@@ -29,7 +29,7 @@ impl Header {
 
         let msb = (octet1 >> 6) as u16;
         let lsb = octet2 as u16;
-        let length = msb << 8 | lsb;
+        let length = (msb << 8) | lsb;
 
         // The second 2 octets are the Vendor ID
         let vendor_id = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/header/flags.rs
+++ b/src/message/avp/header/flags.rs
@@ -28,6 +28,6 @@ impl Flags {
     #[allow(dead_code)] // Remove upon first use
     #[inline]
     pub fn reserved_bits_ok(&self) -> bool {
-        (2..6).into_iter().all(|i| !self.get_bit(i))
+        (2..6).all(|i| !self.get_bit(i))
     }
 }


### PR DESCRIPTION
* Remove unnecessary into_iter() call
* Add parentheses for shift expression