### PR TITLE
Use thiserror for decode error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ phf = { version = "0.10", features = ["macros"] }
 criterion = { version = "0.3", optional = true }
 once_cell = { version = "1.10", optional = true }
 rand = { version = "0.8", optional = true, features = ["small_rng"] }
+thiserror = "2"
 
 [[bench]]
 name = "avp"

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,3 +12,9 @@ pub use vec_writer::*;
 
 mod writer;
 pub use writer::*;
+
+mod decode_error;
+pub use decode_error::*;
+
+mod decode_result;
+pub use decode_result::*;

--- a/src/common/decode_error.rs
+++ b/src/common/decode_error.rs
@@ -1,0 +1,83 @@
+use crate::avp::avp_name;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum DecodeError {
+    #[error("Incomplete AVP ({})", avp_name(*.0))]
+    IncompleteAVP(u16),
+
+    #[error("MessageType AVP with unknown message type ({0})")]
+    UnknownMessageType(u16),
+
+    #[error("AVP ({}) with invalid UTF-8 string payload", avp_name(*.0))]
+    InvalidUtf8(u16),
+
+    #[error("Unknown error type ({0}) in ResultCode AVP")]
+    InvalidResultCodeErrorType(u16),
+
+    #[error("Read error when parsing AVP ({})", avp_name(*.0))]
+    AVPReadError(u16),
+
+    #[error("AVP with invalid length ({0})")]
+    InvalidAVPLength(u16),
+
+    #[error("AVP with unknown type ({0})")]
+    UnknownAvp(u16),
+
+    #[error("Hidden AVP with empty payload")]
+    EmptyHiddenAVP,
+
+    #[error("Hidden AVP with invalid alignment")]
+    MisalignedHiddenAVP,
+
+    #[error("Hidden AVP with invalid original length ({0})")]
+    InvalidOriginalAVPLength(u16),
+
+    #[error("AVP with unsupported vendor ID ({0}) encountered")]
+    UnsupportedVendorId(u16),
+
+    #[error("Message with invalid version field ({0})")]
+    InvalidVersion(u8),
+
+    #[error("Message with invalid reserved bits")]
+    InvalidReservedBits,
+
+    #[error("Message with incomplete flags field")]
+    IncompleteFlags,
+
+    #[error("Message with invalid offset ({0})")]
+    InvalidOffset(u16),
+
+    #[error("Incomplete data message header")]
+    IncompleteDataMessageHeader,
+
+    #[error("Incomplete data message payload")]
+    IncompleteDataMessagePayload,
+
+    #[error("Empty data message payload")]
+    EmptyDataMessagePayload,
+
+    #[error("Read error when parsing message")]
+    MessageReadError,
+
+    #[error("Control message with forbidden message priority present")]
+    ForbiddenControlMessagePriority,
+
+    #[error("Control message with forbidden offset present")]
+    ForbiddenControlMessageOffset,
+
+    #[error("Control message without required length field")]
+    ControlMessageWithoutLength,
+
+    #[error("Control message without required NsNr field")]
+    ControlMessageWithoutNsNr,
+
+    #[error("Incomplete control message header")]
+    IncompleteControlMessageHeader,
+
+    #[error("Incomplete control message payload")]
+    IncompleteControlMessagePayload,
+
+    #[error("First AVP of control message is not MessageType")]
+    ControlMessageTypeNotFirst,
+}

--- a/src/common/decode_result.rs
+++ b/src/common/decode_result.rs
@@ -1,0 +1,3 @@
+use crate::common::DecodeError;
+
+pub type DecodeResult<T> = Result<T, DecodeError>;

--- a/src/common/reader.rs
+++ b/src/common/reader.rs
@@ -1,5 +1,3 @@
-use crate::common::ResultStr;
-
 /// # Summary
 /// A trait representing an abstract reader.
 ///
@@ -23,7 +21,7 @@ pub trait Reader<T> {
 
     /// # Summary
     /// Attempt to read a generic byte slice `length` bytes long.
-    fn bytes(&mut self, length: usize) -> ResultStr<T>;
+    fn bytes(&mut self, length: usize) -> Option<T>;
 
     /// # Summary
     /// Read a single u8.

--- a/src/common/slice_reader.rs
+++ b/src/common/slice_reader.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::common::{Reader, ResultStr};
+use crate::common::Reader;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SliceReader<'a> {
@@ -47,8 +47,8 @@ impl<'a> Reader<&'a [u8]> for SliceReader<'a> {
     }
 
     #[inline]
-    fn bytes(&mut self, length: usize) -> ResultStr<&'a [u8]> {
-        let result = self.data.get(..length).ok_or("Incomplete data");
+    fn bytes(&mut self, length: usize) -> Option<&'a [u8]> {
+        let result = self.data.get(..length);
         self.data = &self.data[length..];
         result
     }

--- a/src/message/avp/types/assigned_session_id.rs
+++ b/src/message/avp/types/assigned_session_id.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AssignedSessionId {
@@ -11,9 +11,9 @@ impl AssignedSessionId {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete AssignedSessionId AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/types/assigned_tunnel_id.rs
+++ b/src/message/avp/types/assigned_tunnel_id.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AssignedTunnelId {
@@ -11,9 +11,9 @@ impl AssignedTunnelId {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete AssignedTunnelId AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/types/bearer_capabilities.rs
+++ b/src/message/avp/types/bearer_capabilities.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BearerCapabilities {
     data: u32,
@@ -19,9 +19,9 @@ impl BearerCapabilities {
     }
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete BearerCapabilities AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let data = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/bearer_type.rs
+++ b/src/message/avp/types/bearer_type.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BearerType {
@@ -19,9 +19,9 @@ impl BearerType {
         }
     }
 
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete BearerType AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let data = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/call_errors.rs
+++ b/src/message/avp/types/call_errors.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CallErrors {
@@ -16,9 +16,9 @@ impl CallErrors {
     const LENGTH: usize = 26;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete CallErrors AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         // Skip reserved

--- a/src/message/avp/types/call_serial_number.rs
+++ b/src/message/avp/types/call_serial_number.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CallSerialNumber {
@@ -11,9 +11,9 @@ impl CallSerialNumber {
     const LENGTH: usize = 4;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete CallSerialNumber AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/called_number.rs
+++ b/src/message/avp/types/called_number.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,14 +11,16 @@ impl CalledNumber {
     const ATTRIBUTE_TYPE: u16 = 21;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete CalledNumber AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
-        let data = reader.bytes(reader.len())?;
+        let data = reader
+            .bytes(reader.len())
+            .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?;
         let value = std::str::from_utf8(data.borrow())
-            .map_err(|_| "Parsing CalledNumber AVP value failed")?
+            .map_err(|_| DecodeError::InvalidUtf8(Self::ATTRIBUTE_TYPE))?
             .to_owned();
 
         Ok(Self { value })

--- a/src/message/avp/types/calling_number.rs
+++ b/src/message/avp/types/calling_number.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,14 +11,16 @@ impl CallingNumber {
     const ATTRIBUTE_TYPE: u16 = 22;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete CallingNumber AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
-        let data = reader.bytes(reader.len())?;
+        let data = reader
+            .bytes(reader.len())
+            .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?;
         let value = std::str::from_utf8(data.borrow())
-            .map_err(|_| "Parsing CallingNumber AVP value failed")?
+            .map_err(|_| DecodeError::InvalidUtf8(Self::ATTRIBUTE_TYPE))?
             .to_owned();
 
         Ok(Self { value })

--- a/src/message/avp/types/challenge.rs
+++ b/src/message/avp/types/challenge.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl Challenge {
     const ATTRIBUTE_TYPE: u16 = 11;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete Challenge AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/challenge_response.rs
+++ b/src/message/avp/types/challenge_response.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 const G_CHALLENGE_RESPONSE_LENGTH: usize = 16;
@@ -14,17 +14,18 @@ impl ChallengeResponse {
     const LENGTH: usize = G_CHALLENGE_RESPONSE_LENGTH;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete ChallengeResponse AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
             value: reader
-                .bytes(16)?
+                .bytes(16)
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
                 .borrow()
                 .try_into()
-                .map_err(|_| "Insufficient data")?,
+                .map_err(|_| DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE))?,
         })
     }
 }

--- a/src/message/avp/types/firmware_revision.rs
+++ b/src/message/avp/types/firmware_revision.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FirmwareRevision {
@@ -11,9 +11,9 @@ impl FirmwareRevision {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete FirmwareRevision AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/types/framing_capabilities.rs
+++ b/src/message/avp/types/framing_capabilities.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FramingCapabilities {
@@ -20,9 +20,9 @@ impl FramingCapabilities {
     }
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete FramingCapabilities AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let data = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/framing_type.rs
+++ b/src/message/avp/types/framing_type.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FramingType {
@@ -20,9 +20,9 @@ impl FramingType {
     }
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete FramingType AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let data = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/host_name.rs
+++ b/src/message/avp/types/host_name.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl HostName {
     const ATTRIBUTE_TYPE: u16 = 7;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete HostName AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/initial_received_lcp_conf_req.rs
+++ b/src/message/avp/types/initial_received_lcp_conf_req.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl InitialReceivedLcpConfReq {
     const ATTRIBUTE_TYPE: u16 = 26;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete InitialReceivedLcpConfReq AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/last_received_lcp_conf_req.rs
+++ b/src/message/avp/types/last_received_lcp_conf_req.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl LastReceivedLcpConfReq {
     const ATTRIBUTE_TYPE: u16 = 28;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete LastReceivedLcpConfReq AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/last_sent_lcp_conf_req.rs
+++ b/src/message/avp/types/last_sent_lcp_conf_req.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl LastSentLcpConfReq {
     const ATTRIBUTE_TYPE: u16 = 27;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete LastSentLcpConfReq AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/maximum_bps.rs
+++ b/src/message/avp/types/maximum_bps.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MaximumBps {
@@ -11,9 +11,9 @@ impl MaximumBps {
     const LENGTH: usize = 4;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete MaximumBps AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/message_type.rs
+++ b/src/message/avp/types/message_type.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 use phf::phf_map;
 
@@ -45,15 +45,15 @@ impl MessageType {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete MessageType AVP payload encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
         let id = unsafe { reader.read_u16_be_unchecked() };
 
         match MESSAGE_CODE_TO_TYPE.get(&id) {
             Some(&t) => Ok(t),
-            None => Err("Unknown MessageType AVP encountered"),
+            None => Err(DecodeError::UnknownMessageType(id)),
         }
     }
 

--- a/src/message/avp/types/minimum_bps.rs
+++ b/src/message/avp/types/minimum_bps.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MinimumBps {
@@ -11,9 +11,9 @@ impl MinimumBps {
     const LENGTH: usize = 4;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete MinimumBps AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/physical_channel_id.rs
+++ b/src/message/avp/types/physical_channel_id.rs
@@ -1,4 +1,4 @@
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use crate::message::avp::{QueryableAVP, WritableAVP};
 use core::borrow::Borrow;
 
@@ -14,14 +14,15 @@ impl PhysicalChannelId {
     const LENGTH: usize = G_PHYSICAL_CHANNEL_ID_LENGTH;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete PhysicalChannelId payload encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe {
             reader
-                .bytes(Self::LENGTH)?
+                .bytes(Self::LENGTH)
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
                 .borrow()
                 .try_into()
                 .unwrap_unchecked()

--- a/src/message/avp/types/private_group_id.rs
+++ b/src/message/avp/types/private_group_id.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl PrivateGroupId {
     const ATTRIBUTE_TYPE: u16 = 37;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete PrivateGroupId AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/protocol_version.rs
+++ b/src/message/avp/types/protocol_version.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProtocolVersion {
@@ -12,9 +12,9 @@ impl ProtocolVersion {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete ProtocolVersion AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let version = unsafe { reader.read_u8_unchecked() };

--- a/src/message/avp/types/proxy_authen_challenge.rs
+++ b/src/message/avp/types/proxy_authen_challenge.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl ProxyAuthenChallenge {
     const ATTRIBUTE_TYPE: u16 = 31;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete ProxyAuthenChallenge AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/proxy_authen_id.rs
+++ b/src/message/avp/types/proxy_authen_id.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProxyAuthenId {
@@ -11,9 +11,9 @@ impl ProxyAuthenId {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete ProxyAuthenId AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         // Reserved

--- a/src/message/avp/types/proxy_authen_name.rs
+++ b/src/message/avp/types/proxy_authen_name.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl ProxyAuthenName {
     const ATTRIBUTE_TYPE: u16 = 30;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete ProxyAuthenName AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/proxy_authen_response.rs
+++ b/src/message/avp/types/proxy_authen_response.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,13 +11,17 @@ impl ProxyAuthenResponse {
     const ATTRIBUTE_TYPE: u16 = 33;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete ProxyAuthenResponse AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
-            value: reader.bytes(reader.len())?.borrow().to_owned(),
+            value: reader
+                .bytes(reader.len())
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
+                .borrow()
+                .to_owned(),
         })
     }
 }

--- a/src/message/avp/types/proxy_authen_type.rs
+++ b/src/message/avp/types/proxy_authen_type.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
@@ -19,16 +19,16 @@ impl ProxyAuthenType {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete ProxyAuthenType AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         unsafe {
             reader
                 .read_u16_be_unchecked()
                 .try_into()
-                .map_err(|_| "Unknown ProxyAuthenType encountered")
+                .map_err(|_| DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE))
         }
     }
 }

--- a/src/message/avp/types/random_vector.rs
+++ b/src/message/avp/types/random_vector.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 const G_RANDOM_VECTOR_LENGTH: usize = 4;
@@ -14,17 +14,18 @@ impl RandomVector {
     const LENGTH: usize = G_RANDOM_VECTOR_LENGTH;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete Random Vector AVP payload encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         Ok(Self {
             value: reader
-                .bytes(4)?
+                .bytes(4)
+                .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?
                 .borrow()
                 .try_into()
-                .map_err(|_| "Insufficient data")?,
+                .map_err(|_| DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE))?,
         })
     }
 }

--- a/src/message/avp/types/receive_window_size.rs
+++ b/src/message/avp/types/receive_window_size.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReceiveWindowSize {
@@ -11,9 +11,9 @@ impl ReceiveWindowSize {
     const LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete ReceiveWindowSize AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/types/result_code.rs
+++ b/src/message/avp/types/result_code.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 mod code;
@@ -20,9 +20,9 @@ impl ResultCode {
     const ERROR_LENGTH: usize = 2;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::FIXED_LENGTH {
-            return Err("Incomplete ResultCode AVP payload encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let code_raw = unsafe { reader.read_u16_be_unchecked() };

--- a/src/message/avp/types/rx_connect_speed.rs
+++ b/src/message/avp/types/rx_connect_speed.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RxConnectSpeed {
@@ -11,9 +11,9 @@ impl RxConnectSpeed {
     const LENGTH: usize = 4;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete RxConnectSpeed AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/sub_address.rs
+++ b/src/message/avp/types/sub_address.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,14 +11,16 @@ impl SubAddress {
     const ATTRIBUTE_TYPE: u16 = 23;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete SubAddress AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
-        let data = reader.bytes(reader.len())?;
+        let data = reader
+            .bytes(reader.len())
+            .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?;
         let value = std::str::from_utf8(data.borrow())
-            .map_err(|_| "Parsing SubAddress advisory message failed")?
+            .map_err(|_| DecodeError::InvalidUtf8(Self::ATTRIBUTE_TYPE))?
             .to_owned();
 
         Ok(Self { value })

--- a/src/message/avp/types/tie_breaker.rs
+++ b/src/message/avp/types/tie_breaker.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TieBreaker {
@@ -11,9 +11,9 @@ impl TieBreaker {
     const LENGTH: usize = 8;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete TieBreaker AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u64_be_unchecked() };

--- a/src/message/avp/types/tx_connect_speed.rs
+++ b/src/message/avp/types/tx_connect_speed.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TxConnectSpeed {
@@ -11,9 +11,9 @@ impl TxConnectSpeed {
     const LENGTH: usize = 4;
 
     #[inline]
-    pub fn try_read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < Self::LENGTH {
-            return Err("Incomplete TxConnectSpeed AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
         let value = unsafe { reader.read_u32_be_unchecked() };

--- a/src/message/avp/types/vendor_name.rs
+++ b/src/message/avp/types/vendor_name.rs
@@ -1,5 +1,5 @@
 use crate::avp::{QueryableAVP, WritableAVP};
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 use core::borrow::Borrow;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,14 +11,16 @@ impl VendorName {
     const ATTRIBUTE_TYPE: u16 = 8;
 
     #[inline]
-    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn try_read<T: Borrow<[u8]>>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.is_empty() {
-            return Err("Incomplete VendorName AVP encountered");
+            return Err(DecodeError::IncompleteAVP(Self::ATTRIBUTE_TYPE));
         }
 
-        let data = reader.bytes(reader.len())?;
+        let data = reader
+            .bytes(reader.len())
+            .ok_or(DecodeError::AVPReadError(Self::ATTRIBUTE_TYPE))?;
         let value = std::str::from_utf8(data.borrow())
-            .map_err(|_| "Parsing VendorName AVP value failed")?
+            .map_err(|_| DecodeError::InvalidUtf8(Self::ATTRIBUTE_TYPE))?
             .to_owned();
 
         Ok(Self { value })

--- a/src/message/flags.rs
+++ b/src/message/flags.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::common::{Reader, ResultStr, Writer};
+use crate::common::{DecodeError, DecodeResult, Reader, Writer};
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum MessageFlagType {
@@ -49,9 +49,9 @@ impl Flags {
     }
 
     #[inline]
-    pub fn read<T>(reader: &mut impl Reader<T>) -> ResultStr<Self> {
+    pub fn read<T>(reader: &mut impl Reader<T>) -> DecodeResult<Self> {
         if reader.len() < 2 {
-            return Err("Incomplete flag section encountered");
+            return Err(DecodeError::IncompleteFlags);
         }
         let data = unsafe { reader.read_u16_be_unchecked() };
         Ok(Self { data })

--- a/src/message/flags/tests.rs
+++ b/src/message/flags/tests.rs
@@ -1,5 +1,5 @@
 use super::{Flags, MessageFlagType};
-use crate::common::SliceReader;
+use crate::common::{DecodeError, SliceReader};
 
 #[test]
 fn from_bytes() {
@@ -27,7 +27,7 @@ fn from_bytes() {
     // Incomplete
     {
         let f = Flags::read(&mut SliceReader::from(&vec![0x00]));
-        assert_eq!(f, Err("Incomplete flag section encountered"));
+        assert_eq!(f, Err(DecodeError::IncompleteFlags));
     }
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -42,7 +42,7 @@ fn try_read_validate_data_invalid_version() {
             unused: ValidateUnused::No,
         },
     );
-    assert_eq!(m, Err("Invalid version encountered"));
+    assert_eq!(m, Err(vec![DecodeError::InvalidVersion(0)]));
 }
 
 #[test]
@@ -106,8 +106,5 @@ fn try_read_validate_control_invalid_priority() {
             unused: ValidateUnused::Yes,
         },
     );
-    assert_eq!(
-        m,
-        Err("Control message with forbidden Priority bit encountered")
-    );
+    assert_eq!(m, Err(vec![DecodeError::ForbiddenControlMessagePriority]));
 }


### PR DESCRIPTION
ResultStr has since the beginning been a trivial placeholder type until real error codes could be instituted. This change starts (and nearly completes) the error code conversion of the codebase. This is a breaking change for the greater good.

While working on this I also changed the signature of some of the decoding functions to instead return a Vec of errors. That means e.g. AVP errors should now actually be propagated to the end user.